### PR TITLE
Apply universal contact form with consent checkboxes

### DIFF
--- a/call-intellect-site/contact-api.js
+++ b/call-intellect-site/contact-api.js
@@ -10,7 +10,7 @@ app.use(cors())
 app.use(express.json())
 
 // Настройка транспорта для отправки email
-const transporter = nodemailer.createTransporter({
+const transporter = nodemailer.createTransport({
   service: 'gmail',
   auth: {
     user: process.env.EMAIL_USER || 'your-email@gmail.com',

--- a/call-intellect-site/src/App.jsx
+++ b/call-intellect-site/src/App.jsx
@@ -2,6 +2,7 @@ import { BrowserRouter as Router, Routes, Route } from 'react-router-dom'
 import { HelmetProvider } from 'react-helmet-async'
 import Header from './components/layout/Header'
 import Footer from './components/layout/Footer'
+import { ContactFormProvider } from './contexts/ContactFormContext'
 import Home from './pages/Home'
 import Sales from './pages/Sales'
 import Marketing from './pages/Marketing'
@@ -9,16 +10,18 @@ import MarketAnalysis from './pages/MarketAnalysis'
 import Blog from './pages/Blog'
 import Contacts from './pages/Contacts'
 import AdminPanel from './pages/AdminPanel'
+import PersonalData from './pages/PersonalData'
 import './App.css'
 
 function App() {
   return (
     <HelmetProvider>
       <Router>
-        <div className="min-h-screen flex flex-col">
-          <Header />
-          <main className="flex-grow">
-            <Routes>
+        <ContactFormProvider>
+          <div className="min-h-screen flex flex-col">
+            <Header />
+            <main className="flex-grow">
+              <Routes>
               <Route path="/" element={<Home />} />
               <Route path="/sales" element={<Sales />} />
               <Route path="/marketing" element={<Marketing />} />
@@ -26,10 +29,12 @@ function App() {
               <Route path="/blog" element={<Blog />} />
               <Route path="/contacts" element={<Contacts />} />
               <Route path="/admin" element={<AdminPanel />} />
-            </Routes>
-          </main>
-          <Footer />
-        </div>
+              <Route path="/personal-data" element={<PersonalData />} />
+              </Routes>
+            </main>
+            <Footer />
+          </div>
+        </ContactFormProvider>
       </Router>
     </HelmetProvider>
   )

--- a/call-intellect-site/src/components/ContactForm.jsx
+++ b/call-intellect-site/src/components/ContactForm.jsx
@@ -86,8 +86,8 @@ const ContactForm = ({ isOpen, onClose, formType = 'general' }) => {
             <div className="w-16 h-16 bg-green-100 rounded-full flex items-center justify-center mx-auto mb-4">
               <Mail className="w-8 h-8 text-green-600" />
             </div>
-            <h3 className="text-xl font-bold text-green-600 mb-2">Заявка отправлена!</h3>
-            <p className="text-gray-600">Мы свяжемся с вами в ближайшее время</p>
+            <h3 className="text-xl font-bold text-green-600 mb-2">Спасибо!</h3>
+            <p className="text-gray-600">Ваша заявка отправлена</p>
           </div>
         ) : (
           <>
@@ -150,6 +150,29 @@ const ContactForm = ({ isOpen, onClose, formType = 'general' }) => {
                     placeholder="your@email.com"
                   />
                 </div>
+              </div>
+
+              <div className="flex items-start space-x-2 pt-2">
+                <input
+                  type="checkbox"
+                  id="agreeData"
+                  defaultChecked
+                  required
+                  className="mt-1"
+                />
+                <label htmlFor="agreeData" className="text-sm text-gray-700">
+                  Подтверждаю свои данные и даю согласие на их обработку{' '}
+                  <a href="/personal-data" className="text-blue-600 hover:underline">
+                    персональных данных
+                  </a>
+                </label>
+              </div>
+
+              <div className="flex items-start space-x-2">
+                <input type="checkbox" id="agreeMaterials" defaultChecked className="mt-1" />
+                <label htmlFor="agreeMaterials" className="text-sm text-gray-700">
+                  Даю свое согласие на получение материала о сервисе
+                </label>
               </div>
 
               <div className="flex gap-3 pt-4">

--- a/call-intellect-site/src/components/layout/Header.jsx
+++ b/call-intellect-site/src/components/layout/Header.jsx
@@ -1,11 +1,13 @@
 import { useState } from 'react'
 import { Link, useLocation } from 'react-router-dom'
+import { useContactForm } from '../../contexts/ContactFormContext'
 import { Button } from '@/components/ui/button'
 import { Menu, X, Phone, MessageCircle } from 'lucide-react'
 
 const Header = () => {
   const [isMenuOpen, setIsMenuOpen] = useState(false)
   const location = useLocation()
+  const { openForm } = useContactForm()
 
   const navigation = [
     { name: 'Главная', href: '/' },
@@ -55,7 +57,11 @@ const Header = () => {
             <a href="tel:+79636165035" className="text-sm hover:text-blue-200">
               +7 (963) 616-50-35
             </a>
-            <Button variant="outline" className="text-blue-600 border-white hover:bg-white">
+            <Button
+              variant="outline"
+              className="text-blue-600 border-white hover:bg-white"
+              onClick={() => openForm('general')}
+            >
               Заказать звонок
             </Button>
           </div>
@@ -89,7 +95,14 @@ const Header = () => {
                 <a href="tel:+79636165035" className="block py-2 text-sm">
                   +7 (963) 616-50-35
                 </a>
-                <Button variant="outline" className="mt-2 text-blue-600 border-white hover:bg-white">
+                <Button
+                  variant="outline"
+                  className="mt-2 text-blue-600 border-white hover:bg-white"
+                  onClick={() => {
+                    setIsMenuOpen(false)
+                    openForm('general')
+                  }}
+                >
                   Заказать звонок
                 </Button>
               </div>

--- a/call-intellect-site/src/contexts/ContactFormContext.jsx
+++ b/call-intellect-site/src/contexts/ContactFormContext.jsx
@@ -1,0 +1,25 @@
+import React, { createContext, useContext, useState } from 'react'
+import ContactForm from '../components/ContactForm'
+
+const ContactFormContext = createContext()
+
+export const ContactFormProvider = ({ children }) => {
+  const [isOpen, setIsOpen] = useState(false)
+  const [formType, setFormType] = useState('general')
+
+  const openForm = (type = 'general') => {
+    setFormType(type)
+    setIsOpen(true)
+  }
+
+  const closeForm = () => setIsOpen(false)
+
+  return (
+    <ContactFormContext.Provider value={{ isOpen, formType, openForm, closeForm }}>
+      {children}
+      <ContactForm isOpen={isOpen} onClose={closeForm} formType={formType} />
+    </ContactFormContext.Provider>
+  )
+}
+
+export const useContactForm = () => useContext(ContactFormContext)

--- a/call-intellect-site/src/pages/Blog.jsx
+++ b/call-intellect-site/src/pages/Blog.jsx
@@ -1,7 +1,9 @@
 import { Button } from '@/components/ui/button'
 import { Calendar, User, ArrowRight } from 'lucide-react'
+import { useContactForm } from '../contexts/ContactFormContext'
 
 const Blog = () => {
+  const { openForm } = useContactForm()
   const blogPosts = [
     {
       id: 1,
@@ -88,7 +90,10 @@ const Blog = () => {
               placeholder="Ваш email"
               className="flex-1 px-4 py-2 rounded-lg text-gray-900"
             />
-            <Button className="bg-white text-blue-600 hover:bg-gray-100">
+            <Button
+              className="bg-white text-blue-600 hover:bg-gray-100"
+              onClick={() => openForm('general')}
+            >
               Подписаться
             </Button>
           </div>

--- a/call-intellect-site/src/pages/Contacts.jsx
+++ b/call-intellect-site/src/pages/Contacts.jsx
@@ -1,8 +1,10 @@
 import { Button } from '@/components/ui/button'
 import { Phone, Mail, MessageCircle, MapPin, Clock } from 'lucide-react'
 import SEOHead from '../components/SEOHead'
+import { useContactForm } from '../contexts/ContactFormContext'
 
 const Contacts = () => {
+  const { openForm } = useContactForm()
   return (
     <div className="min-h-screen">
       <SEOHead 
@@ -33,69 +35,13 @@ const Contacts = () => {
             {/* Contact Form */}
             <div>
               <h2 className="text-3xl font-bold mb-8">Оставьте заявку</h2>
-              <form className="space-y-6">
-                <div>
-                  <label className="block text-sm font-medium text-gray-700 mb-2">
-                    Имя *
-                  </label>
-                  <input
-                    type="text"
-                    required
-                    className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent"
-                    placeholder="Ваше имя"
-                  />
-                </div>
-                <div>
-                  <label className="block text-sm font-medium text-gray-700 mb-2">
-                    Телефон *
-                  </label>
-                  <input
-                    type="tel"
-                    required
-                    className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent"
-                    placeholder="+7 (___) ___-__-__"
-                  />
-                </div>
-                <div>
-                  <label className="block text-sm font-medium text-gray-700 mb-2">
-                    Email
-                  </label>
-                  <input
-                    type="email"
-                    className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent"
-                    placeholder="your@email.com"
-                  />
-                </div>
-                <div>
-                  <label className="block text-sm font-medium text-gray-700 mb-2">
-                    Компания
-                  </label>
-                  <input
-                    type="text"
-                    className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent"
-                    placeholder="Название компании"
-                  />
-                </div>
-                <div>
-                  <label className="block text-sm font-medium text-gray-700 mb-2">
-                    Сообщение
-                  </label>
-                  <textarea
-                    rows={4}
-                    className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent"
-                    placeholder="Расскажите о ваших потребностях..."
-                  />
-                </div>
-                <Button size="lg" className="w-full bg-blue-600 hover:bg-blue-700">
-                  Отправить заявку
-                </Button>
-                <p className="text-sm text-gray-500">
-                  Нажимая кнопку, вы соглашаетесь с{' '}
-                  <a href="#" className="text-blue-600 hover:underline">
-                    политикой конфиденциальности
-                  </a>
-                </p>
-              </form>
+              <Button
+                size="lg"
+                className="w-full bg-blue-600 hover:bg-blue-700"
+                onClick={() => openForm('general')}
+              >
+                Отправить заявку
+              </Button>
             </div>
 
             {/* Contact Details */}
@@ -147,13 +93,24 @@ const Contacts = () => {
               <div className="mt-8 space-y-4">
                 <h3 className="text-xl font-bold">Быстрые действия</h3>
                 <div className="space-y-3">
-                  <Button className="w-full bg-green-600 hover:bg-green-700">
+                  <Button
+                    className="w-full bg-green-600 hover:bg-green-700"
+                    onClick={() => openForm('demo')}
+                  >
                     Заказать демонстрацию
                   </Button>
-                  <Button variant="outline" className="w-full">
+                  <Button
+                    variant="outline"
+                    className="w-full"
+                    onClick={() => openForm('general')}
+                  >
                     Скачать презентацию
                   </Button>
-                  <Button variant="outline" className="w-full">
+                  <Button
+                    variant="outline"
+                    className="w-full"
+                    onClick={() => openForm('calculate')}
+                  >
                     Рассчитать стоимость
                   </Button>
                 </div>

--- a/call-intellect-site/src/pages/Home.jsx
+++ b/call-intellect-site/src/pages/Home.jsx
@@ -1,22 +1,11 @@
 import { Button } from '@/components/ui/button'
 import { CheckCircle, Users, TrendingUp, Clock, Target, BarChart3 } from 'lucide-react'
-import { useState } from 'react'
+import { useContactForm } from '../contexts/ContactFormContext'
 import SEOHead from '../components/SEOHead'
 import FAQSection from '../components/FAQSection'
-import ContactForm from '../components/ContactForm'
 
 const Home = () => {
-  const [isFormOpen, setIsFormOpen] = useState(false)
-  const [formType, setFormType] = useState('general')
-
-  const openForm = (type) => {
-    setFormType(type)
-    setIsFormOpen(true)
-  }
-
-  const closeForm = () => {
-    setIsFormOpen(false)
-  }
+  const { openForm } = useContactForm()
 
   return (
     <div className="min-h-screen">
@@ -186,12 +175,6 @@ const Home = () => {
         </div>
       </section>
 
-      {/* Contact Form Modal */}
-      <ContactForm 
-        isOpen={isFormOpen} 
-        onClose={closeForm} 
-        formType={formType} 
-      />
     </div>
   )
 }

--- a/call-intellect-site/src/pages/MarketAnalysis.jsx
+++ b/call-intellect-site/src/pages/MarketAnalysis.jsx
@@ -1,8 +1,10 @@
 import { Button } from '@/components/ui/button'
 import { BarChart3, PieChart, TrendingUp, Database } from 'lucide-react'
 import SEOHead from '../components/SEOHead'
+import { useContactForm } from '../contexts/ContactFormContext'
 
 const MarketAnalysis = () => {
+  const { openForm } = useContactForm()
   return (
     <div className="min-h-screen">
       <SEOHead 
@@ -22,7 +24,11 @@ const MarketAnalysis = () => {
             <p className="text-xl mb-8">
               Получайте глубокие инсайты о рынке на основе анализа звонков
             </p>
-            <Button size="lg" className="bg-white text-indigo-600 hover:bg-gray-100">
+            <Button
+              size="lg"
+              className="bg-white text-indigo-600 hover:bg-gray-100"
+              onClick={() => openForm('general')}
+            >
               Получить анализ рынка
             </Button>
           </div>
@@ -183,7 +189,11 @@ const MarketAnalysis = () => {
           <p className="text-xl mb-8">
             Узнайте больше о вашем рынке и получите конкурентные преимущества
           </p>
-          <Button size="lg" className="bg-white text-indigo-600 hover:bg-gray-100">
+          <Button
+            size="lg"
+            className="bg-white text-indigo-600 hover:bg-gray-100"
+            onClick={() => openForm('general')}
+          >
             Заказать анализ рынка
           </Button>
         </div>

--- a/call-intellect-site/src/pages/Marketing.jsx
+++ b/call-intellect-site/src/pages/Marketing.jsx
@@ -1,8 +1,10 @@
 import { Button } from '@/components/ui/button'
 import { Search, Filter, Users, TrendingUp } from 'lucide-react'
 import SEOHead from '../components/SEOHead'
+import { useContactForm } from '../contexts/ContactFormContext'
 
 const Marketing = () => {
+  const { openForm } = useContactForm()
   return (
     <div className="min-h-screen">
       <SEOHead 
@@ -22,7 +24,11 @@ const Marketing = () => {
             <p className="text-xl mb-8">
               Анализируйте качество лидов и потребности клиентов с помощью ИИ
             </p>
-            <Button size="lg" className="bg-white text-purple-600 hover:bg-gray-100">
+            <Button
+              size="lg"
+              className="bg-white text-purple-600 hover:bg-gray-100"
+              onClick={() => openForm('general')}
+            >
               Получить маркетинговую аналитику
             </Button>
           </div>
@@ -176,7 +182,11 @@ const Marketing = () => {
           <p className="text-xl mb-8">
             Узнайте больше о ваших клиентах и оптимизируйте маркетинговые кампании
           </p>
-          <Button size="lg" className="bg-white text-purple-600 hover:bg-gray-100">
+          <Button
+            size="lg"
+            className="bg-white text-purple-600 hover:bg-gray-100"
+            onClick={() => openForm('general')}
+          >
             Заказать анализ
           </Button>
         </div>

--- a/call-intellect-site/src/pages/PersonalData.jsx
+++ b/call-intellect-site/src/pages/PersonalData.jsx
@@ -1,0 +1,8 @@
+const PersonalData = () => (
+  <div className="container mx-auto px-4 py-16">
+    <h1 className="text-3xl font-bold mb-4">Согласие на обработку персональных данных</h1>
+    <p>Здесь будет размещен текст соглашения на обработку персональных данных.</p>
+  </div>
+)
+
+export default PersonalData

--- a/call-intellect-site/src/pages/Sales.jsx
+++ b/call-intellect-site/src/pages/Sales.jsx
@@ -1,8 +1,10 @@
 import { Button } from '@/components/ui/button'
 import { TrendingUp, Users, Target, BarChart3 } from 'lucide-react'
 import SEOHead from '../components/SEOHead'
+import { useContactForm } from '../contexts/ContactFormContext'
 
 const Sales = () => {
+  const { openForm } = useContactForm()
   return (
     <div className="min-h-screen">
       <SEOHead 
@@ -22,7 +24,11 @@ const Sales = () => {
             <p className="text-xl mb-8">
               Контроль качества звонков и обучение менеджеров для роста конверсии
             </p>
-            <Button size="lg" className="bg-white text-green-600 hover:bg-gray-100">
+            <Button
+              size="lg"
+              className="bg-white text-green-600 hover:bg-gray-100"
+              onClick={() => openForm('demo')}
+            >
               Получить демо для отдела продаж
             </Button>
           </div>
@@ -109,7 +115,11 @@ const Sales = () => {
           <p className="text-xl mb-8">
             Запишитесь на демонстрацию и узнайте, как Call-Intellect поможет вашему отделу продаж
           </p>
-          <Button size="lg" className="bg-white text-green-600 hover:bg-gray-100">
+          <Button
+            size="lg"
+            className="bg-white text-green-600 hover:bg-gray-100"
+            onClick={() => openForm('demo')}
+          >
             Заказать демонстрацию
           </Button>
         </div>


### PR DESCRIPTION
## Summary
- add ContactForm context for global use
- attach contact form to header and all CTA buttons
- add consent checkboxes to `ContactForm`
- send form to email and show "thank you" state
- provide personal data placeholder page
- fix nodemailer transporter typo

## Testing
- `npx eslint .` *(fails: Cannot find package '@eslint/js')*
- `npm install` *(fails: dependency resolution error)*

------
https://chatgpt.com/codex/tasks/task_e_68579c3e8430832b9e79ba03f482829c